### PR TITLE
Cross-realm and one line in tooltip instead of many

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -140,16 +140,32 @@ function core:OnTooltipSetItem(tooltip, data)
             local r, g, b = NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b
             left = recipetype
             if known == total then
-                right = "Already Known"
+                right = PROFESSIONS_CATEGORY_LEARNED
                 r, g, b = GREEN_FONT_COLOR.r, GREEN_FONT_COLOR.g, GREEN_FONT_COLOR.b
             elseif known == 0 then
-                right = ("%d of %d Unknown"):format(total, total)
+                right = ("%d of %d %s"):format(total, total, PROFESSIONS_CATEGORY_UNLEARNED)
                 r, g, b = RED_FONT_COLOR.r, RED_FONT_COLOR.g, RED_FONT_COLOR.b
             else
-                right = ("%d of %d Partial"):format(total - known, total)
+                right = ("%d of %d %s"):format(total - known, total, INCOMPLETE)
                 r, g, b = 1, 0.82, 0  -- yellow
             end
             tooltip:AddDoubleLine(left, right, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, r, g, b)
+
+            if IsShiftKeyDown() then
+                for realmName, realmchars in pairs(core.db.characters) do
+                    for altName, details in pairs(realmchars) do
+                        if details and details.professions[recipetype] then
+                            local color = RAID_CLASS_COLORS[details.class] or NORMAL_FONT_COLOR
+                            local label = ("%s-%s"):format(altName, realmName)
+                            if details.professions[recipetype][spellid] then
+                                tooltip:AddDoubleLine(label, PROFESSIONS_CATEGORY_LEARNED, color.r, color.g, color.b, GREEN_FONT_COLOR.r, GREEN_FONT_COLOR.g, GREEN_FONT_COLOR.b)
+                            else
+                                tooltip:AddDoubleLine(label, PROFESSIONS_CATEGORY_UNLEARNED, color.r, color.g, color.b, RED_FONT_COLOR.r, RED_FONT_COLOR.g, RED_FONT_COLOR.b)
+                            end
+                        end
+                    end
+                end
+            end
         end
     end
 

--- a/core.lua
+++ b/core.lua
@@ -124,19 +124,32 @@ function core:OnTooltipSetItem(tooltip, data)
         end
         if not spellid then return end
         Debug("Updating tooltip", link, itemid, spellid, recipetype)
-        -- we're on a recipe here!
-        for alt, details in pairs(chars) do
-            Debug("Known on?", alt, details and details.professions[recipetype])
-            if details and details.professions[recipetype] then
-                -- alt knows this profession
-                local color = RAID_CLASS_COLORS[details.class] or NORMAL_FONT_COLOR
-                if details.professions[recipetype][spellid] then
-                    tooltip:AddDoubleLine(alt, ITEM_SPELL_KNOWN, color.r, color.g, color.b, GREEN_FONT_COLOR.r, GREEN_FONT_COLOR.g, GREEN_FONT_COLOR.b)
-                else
-                    -- ...and doesn't know this recipe!
-                    tooltip:AddDoubleLine(alt, LEARN, color.r, color.g, color.b, RED_FONT_COLOR.r, RED_FONT_COLOR.g, RED_FONT_COLOR.b)
+        local total, known = 0, 0
+        for _, realmchars in pairs(core.db.characters) do
+            for _, details in pairs(realmchars) do
+                if details and details.professions[recipetype] then
+                    total = total + 1
+                    if details.professions[recipetype][spellid] then
+                        known = known + 1
+                    end
                 end
             end
+        end
+        if total > 0 then
+            local left, right
+            local r, g, b = NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b
+            left = recipetype
+            if known == total then
+                right = "Already Known"
+                r, g, b = GREEN_FONT_COLOR.r, GREEN_FONT_COLOR.g, GREEN_FONT_COLOR.b
+            elseif known == 0 then
+                right = ("%d of %d Unknown"):format(total, total)
+                r, g, b = RED_FONT_COLOR.r, RED_FONT_COLOR.g, RED_FONT_COLOR.b
+            else
+                right = ("%d of %d Partial"):format(total - known, total)
+                r, g, b = 1, 0.82, 0  -- yellow
+            end
+            tooltip:AddDoubleLine(left, right, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, r, g, b)
         end
     end
 


### PR DESCRIPTION
- Instead of per-realm, we now count per-account/warband, thus making it cross-realm. 
- Added functionality to calculate total and known recipes for a profession and update the tooltip accordingly instead of a long list
- When shift key is held, full character list is shown that are known to have appropriate profession for the recipe (mirrors previous functionality, but now with `character-realm` display name) - No loss of functionality
- Used global constant strings for `Known/Unknown/Incomplete` where needed; this takes care of localization